### PR TITLE
Compatibility with Ruby 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ source "https://rubygems.org"
 ruby "3.3.0"
 
 gem "license_finder", "~> 7.0", require: false
+gem "racc"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       tomlrb (>= 1.3, < 2.1)
       with_env (= 1.1.0)
       xml-simple (~> 1.1.9)
+    racc (1.7.3)
     rexml (3.2.6)
     rubyzip (2.3.2)
     thor (1.3.0)
@@ -21,6 +22,7 @@ PLATFORMS
 
 DEPENDENCIES
   license_finder (~> 7.0)
+  racc
 
 RUBY VERSION
    ruby 3.3.0p0


### PR DESCRIPTION
We expect to be able to revert this change once the upstream issue is resolved.

See https://github.com/pivotal/LicenseFinder/pull/1013 and https://github.com/fbernier/tomlrb/pull/50.
