### PR TITLE
Allow nio4r's complex license

### DIFF
--- a/license_rules.yml
+++ b/license_rules.yml
@@ -125,3 +125,9 @@
     :why: 'Permitted for all use cases: https://tech.powerhrg.com/oss-guide/docs/using/permitted-licenses.html\#permitted-licenses'
     :versions: []
     :when: 2023-08-15 01:13:00.000000000 Z
+- - :permit
+  - MIT AND (BSD-2-Clause OR GPL-2.0-or-later)
+  - :who:
+    :why:
+    :versions: []
+    :when: 2024-01-09 14:04:08.408459000 Z

--- a/license_rules.yml
+++ b/license_rules.yml
@@ -127,7 +127,8 @@
     :when: 2023-08-15 01:13:00.000000000 Z
 - - :permit
   - MIT AND (BSD-2-Clause OR GPL-2.0-or-later)
-  - :who:
-    :why:
+  - :who: Ben Langfeld <blangfeld@powerhrg.com>
+    :why: Each of these licenses is permitted, but license_finder is unable to understand
+      the expression. See https://github.com/pivotal/LicenseFinder/issues/1012.
     :versions: []
-    :when: 2024-01-09 14:04:08.408459000 Z
+    :when: 2024-01-09 14:11:44.344657000 Z


### PR DESCRIPTION
Each of these licenses is permitted, but license_finder is unable to understand the expression, so we'll explicitly allow it.

See:

* https://github.com/powerhome/power-tools/pull/217
* https://github.com/pivotal/LicenseFinder/issues/1012
